### PR TITLE
Fix sidebar navigation error

### DIFF
--- a/features/layout/sidebar-navigation/menu-item-button.tsx
+++ b/features/layout/sidebar-navigation/menu-item-button.tsx
@@ -22,7 +22,12 @@ export function MenuItemButton({
     <li className={classNames(styles.listItem, className)}>
       <Button className={styles.anchor} onClick={onClick}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img className={styles.icon} src={iconSrc} alt={`${text} icon`} />{" "}
+        <img
+          className={styles.icon}
+          src={iconSrc}
+          alt={`${text} icon`}
+          data-collapsed={isCollapsed}
+        />{" "}
         {!isCollapsed && text}{" "}
       </Button>
     </li>

--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -135,6 +135,14 @@
 .collapseMenuItem {
   display: none;
 
+  img {
+    transform: rotate(0deg);
+  }
+
+  img[data-collapsed="true"] {
+    transform: rotate(180deg);
+  }
+
   @media (min-width: breakpoint.$desktop) {
     display: flex;
   }


### PR DESCRIPTION
Use scss selector to grab image within the `collapseMenuItem` class and rotate it based on the value of the `isCollapsed` boolean.