### PR TITLE
insert window resize event

### DIFF
--- a/features/layout/sidebar-navigation/navigation-context.tsx
+++ b/features/layout/sidebar-navigation/navigation-context.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 type NavigationContextProviderProps = {
   children: React.ReactNode;
@@ -18,6 +18,16 @@ export function NavigationProvider({
   const [isSidebarCollapsed, setSidebarCollapsed] = useState(
     defaultContext.isSidebarCollapsed,
   );
+
+  useEffect(() => {
+    function detectWindowSize() {
+      if (window.innerWidth < 1024) setSidebarCollapsed(false);
+    }
+    window.addEventListener("resize", detectWindowSize);
+    return () => {
+      window.removeEventListener("resize", detectWindowSize);
+    };
+  }, []);
 
   return (
     <NavigationContext.Provider


### PR DESCRIPTION
apply a window resize event in a useEffect hook within the navigation-context.tsx file that sets `isSidebaseCollapsed` to false when the screen window shifts to a mobile layout