### PR TITLE
Support button opens email application

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -29,6 +29,14 @@ describe("Sidebar Navigation", () => {
       cy.get("nav")
         .contains("Settings")
         .should("have.attr", "href", "/dashboard/settings");
+
+      cy.get("nav")
+        .contains("Support")
+        .should(
+          "have.attr",
+          "href",
+          "mailto:profysupport@prolog-app.com?subject=Support%20Request%20:&body=message%20goes%20here",
+        );
     });
 
     it("is collapsible", () => {
@@ -36,7 +44,7 @@ describe("Sidebar Navigation", () => {
       cy.get("nav").contains("Collapse").click();
 
       // check that links still exist and are functionable
-      cy.get("nav").find("a").should("have.length", 5).eq(1).click();
+      cy.get("nav").find("a").should("have.length", 6).eq(1).click();
       cy.url().should("eq", "http://localhost:3000/dashboard/issues");
 
       // check that text is not rendered
@@ -80,9 +88,9 @@ describe("Sidebar Navigation", () => {
       isInViewport("nav");
 
       // check that all links are rendered
-      cy.get("nav").find("a").should("have.length", 5);
+      cy.get("nav").find("a").should("have.length", 6);
 
-      // Support button should be rendered but Collapse button not
+      // Support link should be rendered but Collapse button not
       cy.get("nav").contains("Support").should("exist");
       cy.get("nav").contains("Collapse").should("not.be.visible");
 

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -79,14 +79,12 @@ export function SidebarNavigation() {
             ))}
           </ul>
           <ul className={styles.list}>
-            <MenuItemButton
+            <MenuItemLink
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => {
-                window.location.href =
-                  "mailto:profysupport@profy.dev?subject=Support&body=message%20goes%20here";
-              }}
+              href="mailto:profysupport@prolog-app.com?subject=Support%20Request%20:&body=message%20goes%20here"
+              isActive={false}
             />
             <MenuItemButton
               text="Collapse"


### PR DESCRIPTION
Change the support button to a `a` anchor tag and have it link to the correct `mailto:` value to open the user's native email application.