### PR TITLE
cypress timeout

### DIFF
--- a/cypress/e2e/project-list.cy.ts
+++ b/cypress/e2e/project-list.cy.ts
@@ -65,7 +65,7 @@ describe("Project list - Error", () => {
       statusCode: 400,
     }).as("getProjectsWithError");
 
-    cy.wait(7000);
+    cy.wait(9000);
 
     cy.get("main").contains(
       "There was a problem while loading the project data",
@@ -79,7 +79,7 @@ describe("Project list - Error", () => {
       statusCode: 400,
     }).as("getProjectsWithError");
 
-    cy.wait(7000);
+    cy.wait(9000);
 
     cy.get("main").contains(
       "There was a problem while loading the project data",


### PR DESCRIPTION
increase the cypress `.wait` value for the project error endpoint from 7000 milliseconds to 9000 milliseconds.