### PR TITLE
adjust cypress test

### DIFF
--- a/cypress/e2e/project-list.cy.ts
+++ b/cypress/e2e/project-list.cy.ts
@@ -56,16 +56,20 @@ describe("Project List", () => {
 
 describe("Project list - Error", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/dashboard");
-  });
-  it("error message displayed on failed request", () => {
-    // intercept request with error
     cy.intercept("GET", "https://prolog-api.profy.dev/project", {
       body: {},
       statusCode: 400,
     }).as("getProjectsWithError");
 
-    cy.wait(9000);
+    cy.visit("http://localhost:3000/dashboard");
+  });
+  it("error message displayed on failed request", () => {
+    // intercept request with error
+
+    cy.wait("@getProjectsWithError")
+      .wait("@getProjectsWithError")
+      .wait("@getProjectsWithError")
+      .wait("@getProjectsWithError");
 
     cy.get("main").contains(
       "There was a problem while loading the project data",
@@ -74,12 +78,11 @@ describe("Project list - Error", () => {
 
   it("data is successfully retrieved after inital error, data is displayed", () => {
     // intercept request with error
-    cy.intercept("GET", "https://prolog-api.profy.dev/project", {
-      body: {},
-      statusCode: 400,
-    }).as("getProjectsWithError");
 
-    cy.wait(9000);
+    cy.wait("@getProjectsWithError")
+      .wait("@getProjectsWithError")
+      .wait("@getProjectsWithError")
+      .wait("@getProjectsWithError");
 
     cy.get("main").contains(
       "There was a problem while loading the project data",


### PR DESCRIPTION
Manually wait for bad endpoint instead of using `wait`, this is done the amount of times that react-query retries a request (3), also move the intitial intercept into the the `beforeEach`.